### PR TITLE
Update Dockerfile for ReadStats

### DIFF
--- a/QC/docker/read_stats/Dockerfile
+++ b/QC/docker/read_stats/Dockerfile
@@ -1,11 +1,7 @@
-FROM tpesout/hpp_base:latest
+FROM mobinasr/bio_base:v0.3.0
 MAINTAINER Julian Lucas, juklucas@ucsc.edu
 
-ENV PATH="/root/bin/python_3.6.0/bin/:${PATH}"
-ENV PATH="/root/bin/samtools_1.9/:${PATH}"
-
-RUN apt-get update && \
-    apt-get install -y python-matplotlib
+RUN apt-get update
 
 ### FAI READ STATS
 WORKDIR /opt


### PR DESCRIPTION
Use mobinasr/bio_base:v0.3.0 as the base docker image since it does not have the python3 permission issue while running on Slurm